### PR TITLE
Fix linter warning

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -206,6 +206,13 @@ ynh_script_progression --message="Securing files and directories..."
 chown -R "$app":"$app" "$final_path"
 
 #=================================================
+# INTEGRATE SERVICE IN YUNOHOST
+#=================================================
+ynh_script_progression --message="Integrating service in YunoHost..."
+
+yunohost service add $app --description "$app daemon for Wiki.js" --log_type systemd
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Upgrading SSOwat configuration..."


### PR DESCRIPTION
## Problem
- *Linter warning on missing `yunohost service add`*

## Solution
- *Add `yunohost service add`*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wikijs_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wikijs_ynh%20PR-NUM-%20(USERNAME)/)  
