### PR TITLE
Set client max body size

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,9 @@ location / {
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
+
+  client_max_body_size 0;
+
   proxy_set_header Accept-Encoding "";
   proxy_pass http://localhost:__PORT__;
   proxy_set_header Host $http_host;


### PR DESCRIPTION
## Problem
- Can't add media asset with size > 1Mo because Nginx block by default the upload of file > 1 Mo (http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)

## Solution
- Set the client max body size to 0 in order to let wikijs check the maximum size of media asset (5Mo by default but configurable from admin interface)

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wikijs_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wikijs_ynh%20PR-NUM-%20(USERNAME)/)  
