### PR TITLE
Remove the post install mail from the upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Wiki.js is a copylefted libre software, modern and powerful wiki app built on Node.js, Git and Markdown for YunoHost.
 
 
-**Shipped version:** 2.5.289~ynh1
+**Shipped version:** 2.5.289~ynh2
 
 **Demo:** https://docs-beta.requarks.io/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Wiki.js is a copylefted libre software, modern and powerful wiki app built on Node.js, Git and Markdown for YunoHost.
 
 
-**Version incluse :** 2.5.289~ynh1
+**Version incluse :** 2.5.289~ynh2
 
 **Démo :** https://docs-beta.requarks.io/
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source powerful wiki app built on Node.js, Git and Markdown",
         "fr": "Wiki open source propulsé par Node.js, Git et Markdown"
     },
-    "version": "2.5.289~ynh1",
+    "version": "2.5.289~ynh2",
     "url": "https://wiki.js.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Problem

- Whenever you upgrade Wikijs, you get the post install mail

## Solution

- Remove it

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
